### PR TITLE
moved Terrarium logic out of explore into own component

### DIFF
--- a/components/Terriarum.js
+++ b/components/Terriarum.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+    Image,
+    ScrollView,
+    TouchableOpacity
+  } from "react-native";
+import {Card, Badge, Button, Block, Text, Divider} from "../components";
+import {theme} from "../constants";
+
+export default class Terrarium extends React.Component {
+    render() {
+        // deconstructing props so I don't have to use this.props a trillion times
+        const {styles, name, plants, profile} = this.props;
+        return (
+            <Block>
+                <Block flex={false} row center space="between" style={styles.header}>
+                    <Text h1 bold>
+                      {name}
+                    </Text>
+                    <Button onPress={() => navigation.navigate("Settings")}>
+                        <Image source={profile.avatar} style={styles.avatar} />
+                    </Button>
+                </Block>
+                <ScrollView
+                showsVerticalScrollIndicator={false}
+                style={{ paddingVertical: theme.sizes.base * 2 }}
+                >
+                    <Divider margin={[theme.sizes.base, theme.sizes.base * 2]} />
+                    <Block flex={false} row space="between" style={styles.categories}>
+                    {plants.map(plant => (
+                        <TouchableOpacity
+                        key={plant.name}
+                        onPress={() => navigation.navigate("Explore", {plant})}
+                        >
+                            <Card center middle shadow style={styles.category}>
+                            <Badge
+                                margin={[0, 0, 15]}
+                                size={50}
+                                color="rgba(41,216,143,0.20)"
+                            >
+                            <Image source={plant.image} />
+                            </Badge>
+                            <Text medium height={20}>
+                              {plant.name}
+                            </Text>
+                            <Text gray caption>
+                              {plant.description} 
+                            </Text>
+                            </Card>
+                        </TouchableOpacity>
+                        ))}
+                    </Block>
+                </ScrollView>
+            </Block>
+        )
+    }
+}

--- a/components/Terriarum.js
+++ b/components/Terriarum.js
@@ -53,7 +53,9 @@ export default class Terrarium extends React.Component {
                 </Block>
                 <Block flex={false} row center space="between" style={styles.actionButtons}>
                     {this.buttons.map(button => (
-                        <Button key={button.id} gradient={button === this.state.selectedButton} onPress={() =>{
+                        <Button key={button.id} style={{
+                            width: 100
+                        }}gradient={button === this.state.selectedButton} onPress={() =>{
                             this.onButtonPress(button)
                         }}>
                             <Text bold center>

--- a/components/Terriarum.js
+++ b/components/Terriarum.js
@@ -17,21 +17,25 @@ export default class Terrarium extends React.Component {
         }
         this.buttons = [{
             id: 'water',
-            name: "Water Plant"
+            name: "Water Plant",
+            tip: 'water it'
         },
         {
             id: 'talk',
-            name: "Talk to Plant"
+            name: "Talk to Plant",
+            tip:'talk to it'
         },
         {
             id: 'sunlight',
-            name: "Sunlight"
+            name: "Sunlight",
+            tip: 'give it some sun'
         }]
     }
     onButtonPress(button) {
         // make it so when button is clicked, button is set in state
+        // I am setting button to state so I can dynamically render the tips
         this.setState({
-            selectedButton: button.id
+            selectedButton: button
         })
     }
     render() {
@@ -47,9 +51,9 @@ export default class Terrarium extends React.Component {
                         <Image source={profile.avatar} style={styles.avatar} />
                     </Button>
                 </Block>
-                <Block flex={true} row center space="between" style={styles.header}>
+                <Block flex={false} row center space="between" style={styles.actionButtons}>
                     {this.buttons.map(button => (
-                        <Button key={button.id} gradient={button.id === this.state.selectedButton} onPress={() =>{
+                        <Button key={button.id} gradient={button === this.state.selectedButton} onPress={() =>{
                             this.onButtonPress(button)
                         }}>
                             <Text bold center>
@@ -58,9 +62,15 @@ export default class Terrarium extends React.Component {
                         </Button>
                     ))}
                 </Block>
+                {/* displaying tip below buttons */}
+                <Block flex={false} row style={styles.header}>
+                  {this.state.selectedButton !== undefined && (
+                      <Text h3> Click on your plant to {this.state.selectedButton.tip}.</Text>
+                      )}
+                </Block>
                 <ScrollView
                 showsVerticalScrollIndicator={false}
-                style={{ paddingVertical: theme.sizes.base * 2 }}
+                style={{ paddingBottom: theme.sizes.base * 2 }}
                 >
                     <Divider margin={[theme.sizes.base, theme.sizes.base * 2]} />
                     <Block flex={false} row space="between" style={styles.categories}>

--- a/components/Terriarum.js
+++ b/components/Terriarum.js
@@ -6,8 +6,28 @@ import {
   } from "react-native";
 import {Card, Badge, Button, Block, Text, Divider} from "../components";
 import {theme} from "../constants";
-
+// Notes: Step 1: Make an arr of buttons to iterate over
+         // Step2: Disable buttons that aren't pressed through each iteration
+        // Step 3: Track if specific button is currently selected using a state value
 export default class Terrarium extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            selectedButton: undefined
+        }
+        this.buttons = [{
+            id: 'water',
+            name: "Water Plant"
+        },
+        {
+            id: 'talk',
+            name: "Talk to Plant"
+        },
+        {
+            id: 'sunlight',
+            name: "Sunlight"
+        }]
+    }
     render() {
         // deconstructing props so I don't have to use this.props a trillion times
         const {styles, name, plants, profile} = this.props;
@@ -20,6 +40,17 @@ export default class Terrarium extends React.Component {
                     <Button onPress={() => navigation.navigate("Settings")}>
                         <Image source={profile.avatar} style={styles.avatar} />
                     </Button>
+                </Block>
+                <Block flex={true} row center space="between" style={styles.header}>
+                    {this.buttons.map(button => (
+                        <Button key={button.id} gradient={false} onPress={() =>{
+                            
+                        }}>
+                            <Text bold center>
+                              {button.name} 
+                            </Text>
+                        </Button>
+                    ))}
                 </Block>
                 <ScrollView
                 showsVerticalScrollIndicator={false}

--- a/components/Terriarum.js
+++ b/components/Terriarum.js
@@ -32,10 +32,21 @@ export default class Terrarium extends React.Component {
         }]
     }
     onButtonPress(button) {
-        // make it so when button is clicked, button is set in state
+        // Make it so when button is clicked, button is set in state
         // I am setting button to state so I can dynamically render the tips
         this.setState({
             selectedButton: button
+        })
+    }
+    onPlantSelect(plant) {
+        // If no button is selected, do nothing
+        if(this.state.selectedButton === undefined) {
+            return
+        }
+        // TODO: call backend with plant AND action
+        console.log(`performing action ${this.state.selectedButton.id} on plant ${plant.id}` )
+        this.setState({
+            selectedButton: undefined
         })
     }
     render() {
@@ -79,7 +90,7 @@ export default class Terrarium extends React.Component {
                     {plants.map(plant => (
                         <TouchableOpacity
                         key={plant.name}
-                        onPress={() => navigation.navigate("Explore", {plant})}
+                        onPress={() => {this.onPlantSelect(plant)}}
                         >
                             <Card center middle shadow style={styles.category}>
                             <Badge

--- a/components/Terriarum.js
+++ b/components/Terriarum.js
@@ -28,6 +28,12 @@ export default class Terrarium extends React.Component {
             name: "Sunlight"
         }]
     }
+    onButtonPress(button) {
+        // make it so when button is clicked, button is set in state
+        this.setState({
+            selectedButton: button.id
+        })
+    }
     render() {
         // deconstructing props so I don't have to use this.props a trillion times
         const {styles, name, plants, profile} = this.props;
@@ -43,8 +49,8 @@ export default class Terrarium extends React.Component {
                 </Block>
                 <Block flex={true} row center space="between" style={styles.header}>
                     {this.buttons.map(button => (
-                        <Button key={button.id} gradient={false} onPress={() =>{
-                            
+                        <Button key={button.id} gradient={button.id === this.state.selectedButton} onPress={() =>{
+                            this.onButtonPress(button)
                         }}>
                             <Text bold center>
                               {button.name} 

--- a/screens/Explore.js
+++ b/screens/Explore.js
@@ -152,6 +152,11 @@ const styles = StyleSheet.create({
     header: {
       paddingHorizontal: theme.sizes.base * 2
     },
+    actionButtons: {
+        paddingBottom: theme.sizes.base / 4,
+        paddingTop: theme.sizes.base,
+        paddingHorizontal: theme.sizes.base * 2
+      },
     avatar: {
       height: theme.sizes.base * 3.2,
       width: theme.sizes.base * 3.2,
@@ -168,5 +173,4 @@ const styles = StyleSheet.create({
         maxWidth: (width - theme.sizes.padding * 2.4 - theme.sizes.base) / 2,
         maxHeight: (width - theme.sizes.padding * 2.4 - theme.sizes.base) / 2
     }
-
   });

--- a/screens/Explore.js
+++ b/screens/Explore.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity
 } from "react-native";
 import Game from "../components/Game";
-
+import Terrarium from '../components/Terriarum';
 import { Card, Badge, Button, Block, Text, Divider } from "../components";
 import { theme, mocks } from "../constants";
 const BasicSvg = () =>{
@@ -44,15 +44,12 @@ constructor(props){
       }
 
     render(){
-        
         const {profile, navigation} = this.props;
         const { plants1 } = this.state;
         const { plants2 } = this.state;
         const { shopPlants } = this.state;
         const category = navigation.getParam('category');
         const plant = navigation.getParam('plant') || 'plant';
-        
-
         const If = (props) => {
             return props.condition ? props.children : null;
           }
@@ -60,116 +57,13 @@ constructor(props){
         return (
             <>
             <If condition={category.name === 'Happy Terrarium'}>
-            <Block>
-                <Text>
-            {JSON.stringify(this.props.user)}
-
-                </Text>
-            </Block>
-            <Block>
-                <Block flex={false} row center space="between" style={styles.header}>
-                    <Text h1 bold>
-                    {category.name}
-                    </Text>
-                    <Button onPress={() => navigation.navigate("Settings")}>
-                        <Image source={profile.avatar} style={styles.avatar} />
-                    </Button>
-                </Block>
-                <Block center middle>
-                    
-                    <Text>{plant.name}</Text>
-                    <Image source={plant.image} />
-                    <Text>{plant.status}</Text>    
-                </Block>
-                
-                <ScrollView
-                showsVerticalScrollIndicator={false}
-                style={{ paddingVertical: theme.sizes.base * 2 }}
-                >
-                    <Divider margin={[theme.sizes.base, theme.sizes.base * 2]} />
-                    <Block flex={false} row space="between" style={styles.categories}>
-                    {plants1.map(plant=> (
-                        <TouchableOpacity
-                        key={plant.name}
-                        onPress={() => navigation.navigate("Explore", { plant })}
-                        >
-                            <Card center middle shadow style={styles.category}>
-                            <Badge
-                            margin={[0, 0, 15]}
-                            size={50}
-                            color="rgba(41,216,143,0.20)"
-                            >
-                            <Image source={plant.image} />
-                            </Badge>
-                            <Text medium height={20}>
-                            {plant.name}
-                            </Text>
-                            <Text gray caption>
-                            {plant.description} 
-                            </Text>
-                            </Card>
-                        </TouchableOpacity>
-                        ))}
-                    </Block>
-                </ScrollView>
-
-            </Block>
+                {/* Terrarium component is dropped in here to reduce Explorer
+                file complexity */}
+                <Terrarium name={category.name} profile={profile} plants={plants1} styles={styles}/>
             </If>
-
-
             {/* If lucky terrarium */}
-            
-            
-            
             <If condition={category.name === 'Lucky Terrarium'}>
-            <Block>
-                <Block flex={false} row center space="between" style={styles.header}>
-                    <Text h1 bold>
-                    {category.name}
-                    </Text>
-                    <Button onPress={() => navigation.navigate("Settings")}>
-                        <Image source={profile.avatar} style={styles.avatar} />
-                    </Button>
-                </Block>
-                <Block center middle>
-                    
-                    <Text>{plant.name}</Text>
-                    <Image source={plant.image} />
-                    <Text>{plant.status}</Text>    
-                    
-                </Block>
-                <ScrollView
-                showsVerticalScrollIndicator={false}
-                style={{ paddingVertical: theme.sizes.base * 2 }}
-                >
-                    <Divider margin={[theme.sizes.base, theme.sizes.base * 2]} />
-                    <Block flex={false} row space="between" style={styles.categories}>
-                    {plants2.map(plant=> (
-                        <TouchableOpacity
-                        key={plant.name}
-                        onPress={() => navigation.navigate("Explore", { plant })}
-                        >
-                            <Card center middle shadow style={styles.category}>
-                            <Badge
-                            margin={[0, 0, 15]}
-                            size={50}
-                            color="rgba(41,216,143,0.20)"
-                            >
-                            <Image source={plant.image} />
-                            </Badge>
-                            <Text medium height={20}>
-                            {plant.name}
-                            </Text>
-                            <Text gray caption>
-                            {plant.description} 
-                            </Text>
-                            </Card>
-                        </TouchableOpacity>
-                        ))}
-                    </Block>
-                </ScrollView>
-
-            </Block>
+              <Terrarium name={category.name} profile={profile} plants={plants2} styles={styles}/>
             </If>
 
             {/* Store */}
@@ -184,22 +78,16 @@ constructor(props){
                         <Image source={profile.avatar} style={styles.avatar} />
                     </Button>
                 </Block>
-                
-
                 <ScrollView
                 showsVerticalScrollIndicator={false}
                 style={{ paddingVertical: theme.sizes.base * 2 }}
                 >
-
                 <Block center middle>
-                    
                     <Text>{plant.name}</Text>
                     <Image source={plant.image} />
                     <Text>{plant.price}</Text>   
                 </Block>
-
                 <Divider margin={[theme.sizes.base, theme.sizes.base * 2]} />
-                
                     <Block flex={false} row space="between" style={styles.categories}>
                     {shopPlants.map(plant=> (
                         <TouchableOpacity


### PR DESCRIPTION
- [x] Added `Terriarum.js` component and removed the Terrarium logic out of `Explore.js` to separate logic out accordingly. 
    -  Dropped in `Terrarium.js` component into Explorer.js reducing file complexity:
    `<Terrarium name={category.name} profile={profile} plants={plants1} styles={styles}/>` (example)
   - Added buttons array of objects with key's of: `id`, `name` and `tip` and values to match actions team discussed
   - Removed whitespace in `Explorer.js` page and cleaned up a bit
- [x] Created action buttons dynamically that correspond to event listeners that display the on the `Explore.js`
    - Created the following handlers:
        - `onButtonPress` and `onPlantSelect`
     - Added tips dynamically onButtonPress that tell the user to click on the plant (incorporating action names we discussed) Ex: "Click on your Plant to talk to it", "Click on your plant to give it some light" etc.
 - [x] Added button styles: When the user click on button, used gradient attribute to change color of button (matching style Rizo already set up for other buttons as call to actions should be the same)
 - [x] Added `console.log` on `Terriarum.js` to demonstrate where the client will call the backend for **US2 Task 3** including the action, id, and plant id
