### PR TITLE
removed separate Oauth screen from flow

### DIFF
--- a/OauthLogin.js
+++ b/OauthLogin.js
@@ -1,8 +1,6 @@
 import React, {Component} from "react";
-//import React, { useEffect, useState } from 'react';
 import * as Google from 'expo-google-app-auth';
-import {Text, View, StyleSheet, Button } from 'react-native';
-import Login from './screens/Login';
+import { Button, Text } from "./components";
 
 const IOS_CLIENT_ID = '872509857984-nv75qdpnj41i8qjfeb5pplnncmnd6stv.apps.googleusercontent.com';
 const initialState = {
@@ -37,18 +35,10 @@ export default class LoginScreen extends Component {
 
   render() {
       return(
-          <View style={styles.container}>
-              <Button title="Login with Google" onPress={this.signInWithGoogle}/>
-          </View>
+          <Button onPress={this.signInWithGoogle}>
+               <Text center semibold>Login with Google</Text>
+          </Button>
       )
   }
 }
 
-const styles = StyleSheet.create({
-    container: {
-        flex:1,
-        backgroundColor:'#fff',
-        alignItems: 'center',
-        justifyContent: 'center', 
-   }
-})

--- a/screens/Login.js
+++ b/screens/Login.js
@@ -128,9 +128,7 @@ export default class Login extends Component {
                 Forgot your password?
               </Text>
             </Button>
-            <Button gradient onPress={() => this.props.navigation.navigate('OAuth')}>
-              <Text center semibold white>Google Oauth</Text>
-            </Button>
+            <OAuth/>
             <Button gradient onPress={() => this.props.navigation.navigate('Collection')}>
               <Text center semibold white>BYPASS</Text>
             </Button>


### PR DESCRIPTION
- [x] Removed separate (white) Login with Google screen
- [x] Changed `OAuth.js` from screen to a button
    - I put this button on the Login page
    - The new button says "Login with Google"
    - When the user clicks on this button, Google Oauth flow immediately kicks in, no more separate white page